### PR TITLE
Update webpack dev server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ You can specify a version:
 
 	<script src="https://[cdn-url]/gfw-assets.v0.1.0.js"></script>
 
+The `cdn-url` in development will be the webpack dev server, which is
+mounted on http://localhost:9090
+
 ## Contributing
 
 1. Fork it!

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "xo": "^0.13.0"
   },
   "scripts": {
-    "start": "./node_modules/.bin/webpack-dev-server --hot --progress --color --host 0.0.0.0",
+    "start": "./node_modules/.bin/webpack-dev-server --hot --progress --color --host 0.0.0.0 --port 9090",
     "build": "./node_modules/.bin/webpack --progress --color",
     "test": "./node_modules/.bin/karma start --single-run",
     "test-watch": "./node_modules/.bin/karma start --auto-watch"


### PR DESCRIPTION
Currently it conflicts with the GFW python API when running locally (this runs on 8080).
