### PR TITLE
Fixes log in window on Safari

### DIFF
--- a/src/styles/modules/footer.scss
+++ b/src/styles/modules/footer.scss
@@ -685,7 +685,7 @@
 
     position: relative;
     width: 475px;
-    height: 360px;
+    height: 350px;
     padding: 30px 50px 53px 50px;
   }
 
@@ -733,6 +733,7 @@
   .my-gfw-content {
     display: flex;
     width: 100%;
+    height: 100%;
 
     flex-direction: column;
     align-items: center;
@@ -740,7 +741,7 @@
   }
 
   .my-gfw-authentication {
-    margin-top: 20px;
+    margin-top: 40px;
     height: 100%;
     width: 100%;
 


### PR DESCRIPTION
<img width="649" alt="screenshot 2016-04-12 13 49 57" src="https://cloud.githubusercontent.com/assets/182921/14458983/7b94e062-00b5-11e6-95b2-5414cc41210c.png">

vs

<img width="562" alt="screenshot 2016-04-12 13 50 29" src="https://cloud.githubusercontent.com/assets/182921/14458989/8b054b7c-00b5-11e6-9cd1-93931731e146.png">
