### PR TITLE
Menu: iOS scroll issues

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,4 @@
+Last 2 versions
+Safari 7
+Safari 8
+iOS 7

--- a/src/scripts/modules/header/index.js
+++ b/src/scripts/modules/header/index.js
@@ -58,6 +58,7 @@ class Header {
     this.$header = $gfwdom('#headerGfw');
     this.$headerSubmenu = this.$header.find('.m-header-submenu');
     this.$headerSubmenuBtns = this.$header.find('.m-header-submenu-btn');
+    this.$headerSubmenuMenuMobile = this.$header.find('#submenuMenuMobile');
     this.$headerSubmenuApp = this.$header.find('#submenuApps');
     this.$headerSubmenuMore = this.$header.find('#submenuMore');
     this.$headerSubmenuLogin = this.$header.find('#submenuLogin');
@@ -97,11 +98,14 @@ class Header {
    * - sendAnalyticsEvent()
    */
   initListeners() {
-    // Mobile menus
+    // Resize
+    $gfwdom(window).on('resize.assets', this.resizeMenu.bind(this))
+    // Menus
     this.$header.on('click', '.m-header-submenu-btn', this.showMenu.bind(this));
     this.$header.on('click', '.m-header-backdrop', this.hideMenus.bind(this));
     this.$header.on('click', '.m-apps-close', this.hideMenus.bind(this));
 
+    // Search
     this.$header.on('click', '.btn-search', this.toggleSearch.bind(this));
 
     // Be careful, this will break down the mobile menus toggle
@@ -116,14 +120,17 @@ class Header {
       this.hideMenus();
       // Prevent mobile scroll
       if (utils.getWindowWidth() < 850) {
+        this.resizeMenu();
         this.$htmlbody.toggleClass('-no-scroll');
       }
 
-      // Active menu icon
+      // Active menu icon && currentTarget
       $gfwdom(currentTarget).toggleClass('-active')
       $gfwdom(currentTarget).find('svg').toggleClass('-inactive');
+
       // Active menu
-      $gfwdom($gfwdom(currentTarget).data('submenu')).toggleClass('-active');
+      var $current = $gfwdom($gfwdom(currentTarget).data('submenu'));
+      $current.toggleClass('-active');
 
       // Key bindings
       this.$document.on('keyup.apps', e => {
@@ -148,10 +155,11 @@ class Header {
   hideMenus(e) {
     // Allow mobile scroll
     this.$htmlbody.removeClass('-no-scroll');
-    this.$headerSubmenu.removeClass('-active');
-    this.$headerSubmenuApp.removeClass('-active');
-    this.$headerSubmenuMore.removeClass('-active');
-    this.$header.find('#submenuLogin').removeClass('-active');
+    this.$headerSubmenu.removeClass('-active').css({ height: 'auto' });
+    this.$headerSubmenuApp.removeClass('-active').css({ height: 'auto' });
+    this.$headerSubmenuMore.removeClass('-active').css({ height: 'auto' });
+    this.$headerSubmenuMenuMobile.removeClass('-active').css({ height: 'auto' });
+    this.$header.find('#submenuLogin').removeClass('-active').css({ height: 'auto' });
     this.$header.find('.m-header-submenu-btn').forEach(function(v){
       if ($gfwdom(v).hasClass('-active')) {
         $gfwdom(v).removeClass('-active')
@@ -163,6 +171,27 @@ class Header {
 
     // Click bindings
     this.$document.off('click.apps');
+  }
+
+  resizeMenu() {
+    if (utils.getWindowWidth() < 700) {
+      this.$headerSubmenu.forEach(function(v){
+        $gfwdom(v).css({
+          height: utils.getWindowHeigth() - 50 + 'px'
+        });
+      })
+    } else {
+      this.$headerSubmenu.forEach(function(v){
+        $gfwdom(v).css({ height: 'auto' });
+      });
+    }
+
+    if (utils.getWindowWidth() < 850) {
+      this.$headerSubmenuMenuMobile.css({
+        height: utils.getWindowHeigth() - 50 + 'px'
+      });
+    }
+
   }
 
   toggleSearch(e) {

--- a/src/styles/modules/header.scss
+++ b/src/styles/modules/header.scss
@@ -13,7 +13,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  transform: translateZ(0);
+  // transform: translateZ(0);
 
   @media (min-width: $br-mobile){
     position: relative;

--- a/src/styles/modules/header.scss
+++ b/src/styles/modules/header.scss
@@ -13,7 +13,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  // transform: translateZ(0);
+  transform: translateZ(0);
 
   @media (min-width: $br-mobile){
     position: relative;

--- a/src/styles/modules/logos-sprite.scss
+++ b/src/styles/modules/logos-sprite.scss
@@ -1502,13 +1502,20 @@ The provided mixins are intended to be used with the array-like variables
   @include sprite($icon-email);
 }
 
-Here are example usages in HTML:
+Example usage in HTML:
 
 `display: block` sprite:
 <div class="icon-home"></div>
 
-`display: inline-block` sprite:
-<img class="icon-home" />
+To change `display` (e.g. `display: inline-block;`), we suggest using a common CSS class:
+
+// CSS
+.icon {
+  display: inline-block;
+}
+
+// HTML
+<i class="icon icon-home"></i>
 */
 @mixin sprite-width($sprite) {
   width: nth($sprite, 5);

--- a/src/styles/modules/submenu.scss
+++ b/src/styles/modules/submenu.scss
@@ -266,9 +266,9 @@
         max-height: 100%;
         @media (min-width: $br-mobile){
           display: flex;
+          justify-content: space-between;
           position: relative;
           bottom: auto;
-          justify-content: space-between;
         }
 
         > li {
@@ -448,6 +448,7 @@
         font-size: 14px;
         color: $white;
         text-align: center;
+        margin: 0 auto;
         @media (min-width: $br-mobile){
           text-align: left;
         }
@@ -464,7 +465,8 @@
         padding: 20px 40px 40px;
 
         li {
-          width: 250px;
+          width: 100%;
+          max-width: 250px;
           display: block;
           height: 50px;
           text-align: center;
@@ -472,6 +474,7 @@
           position: relative;
           @media (min-width: $br-mobile){
             margin: 0 0 10px;
+            width: 250px;
           }
 
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const path = require('path');
 const SpritesmithPlugin = require('webpack-spritesmith');
+process.env.BROWSERSLIST_CONFIG = 'browserslist';
 
 module.exports = {
 


### PR DESCRIPTION
This PR adds javascript to handle the heights of the submenus. Due to iOS, we need to do this instead of using our last code (better done only CSS :)).

Let's try it a couple of times more in different iOS versions and see if it works well.
