### PR TITLE
Only redirect when logging in from some pages.

### DIFF
--- a/src/scripts/modules/my-gfw/login-button.js
+++ b/src/scripts/modules/my-gfw/login-button.js
@@ -65,7 +65,12 @@ class LoginButton {
   checkCompleteProfile(response) {
     const profileComplete = response.data !== null &&
       response.data.attributes.profileComplete !== false;
-    if (!profileComplete && (window.location.pathname.indexOf('my_gfw') === -1)) {
+    // Only require from specific paths;
+    const pathsRequireCompletion = [
+      'my_gfw/subscriptions/new',
+      'stories/new'
+    ];
+    if (!profileComplete && (pathsRequireCompletion.indexOf(window.location.pathname) > -1))
       window.location.href = '/my_gfw';
     }
   }


### PR DESCRIPTION
Not all pages require the email and language from the user profile
so we don't need to redirect in all of the pages, but only in
subscriptions creation and stories creation.

ToDo: I believe that in the main project we need to ensure that the user is redirected when going to `my_gfw/subscriptions/new` as this fix is only for the moment of logging in.