### PR TITLE
Updated connect.wri form to https

### DIFF
--- a/src/scripts/modules/contact/contact.tpl
+++ b/src/scripts/modules/contact/contact.tpl
@@ -93,7 +93,7 @@
               <h3>Subscribe me to the GFW Newsletter!</h3>
             </header>
             <div class="modal-step-content">
-              <iframe scrolling="no" src="http://connect.wri.org/l/120942/2016-02-08/2trw5q" width="100%" height="900" type="text/html" frameborder="0" allowTransparency="true" style="border: 0"></iframe>
+              <iframe scrolling="no" src="https://connect.wri.org/l/120942/2016-02-08/2trw5q" width="100%" height="900" type="text/html" frameborder="0" allowTransparency="true" style="border: 0"></iframe>
             </div>
           </li>
 


### PR DESCRIPTION
## Mixed Content Fix

This simple fix allows the GFW header to be served completely over HTTPS. This link is the only asset being served over HTTP, and is now securely available!

## The Issue

![screen shot 2018-02-26 at 7 50 56 am](https://user-images.githubusercontent.com/5713523/36671527-dc469eac-1ac9-11e8-97e1-f74ab41bed99.png)

Applications referencing the asset's Nightly build are throwing Mixed Content errors and cannot fully support HTTPS. 

![screen shot 2018-02-26 at 7 53 38 am](https://user-images.githubusercontent.com/5713523/36671603-36e043ae-1aca-11e8-94ec-810d175ce6a2.png)

Now that this form has been made available over HTTPS, we can serve it as such!


