### PR TITLE
Updated GFW Search references to https

### DIFF
--- a/src/scripts/modules/contact/contact.tpl
+++ b/src/scripts/modules/contact/contact.tpl
@@ -93,7 +93,7 @@
               <h3>Subscribe me to the GFW Newsletter!</h3>
             </header>
             <div class="modal-step-content">
-              <iframe scrolling="no" src="http://connect.wri.org/l/120942/2016-02-08/2trw5q" width="100%" height="900" type="text/html" frameborder="0" allowTransparency="true" style="border: 0"></iframe>
+              <iframe scrolling="no" src="https://connect.wri.org/l/120942/2016-02-08/2trw5q" width="100%" height="900" type="text/html" frameborder="0" allowTransparency="true" style="border: 0"></iframe>
             </div>
           </li>
 

--- a/src/scripts/modules/header/header.tpl
+++ b/src/scripts/modules/header/header.tpl
@@ -49,7 +49,7 @@
     <div class="m-header-sub-menu-dashboard sub-menu" id="dashboard-sub-menu">
       <div class="nav-sub-menu-container">
         <div class="form-search-container">
-          <form class="search-container" id="search-container" action="http://www.globalforestwatch.org/search">
+          <form class="search-container" id="search-container" action="https://www.globalforestwatch.org/search">
             <input type="text" name="query" id="search-input" placeholder="SEARCH"/>
             <button type="submit"><svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#gfw-header-icon-h-search"></use></svg></button>
           </form>

--- a/src/scripts/modules/navigation/navigation.tpl
+++ b/src/scripts/modules/navigation/navigation.tpl
@@ -11,7 +11,7 @@
   <%}%>
 
   <li>
-    <form action="http://www.globalforestwatch.org/search">
+    <form action="https://www.globalforestwatch.org/search">
       <button type="submit"><svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#gfw-header-icon-h-search"></use></svg></button>
       <input type="text" name="query" id="search-input-mobile" placeholder="Search GFW website">
     </form>


### PR DESCRIPTION
## Additional Mixed Content

I found two additional links being served over HTTP. This time, I updated a forked assets repo & served it to Fires Staging, which worked completely. 

## Example

We still had two links served over HTTP:

<img width="957" alt="screen shot 2018-02-26 at 1 06 19 pm" src="https://user-images.githubusercontent.com/5713523/36686991-3aa32b1a-1af6-11e8-9f1a-e6f1a6d47a09.png">

So I converted to https, built the assets with `npm run nightly`, pushed it up to s3, and tested https://fires-staging.globalforestwatch.org/home/ against that build. It works!

<img width="962" alt="screen shot 2018-02-26 at 1 07 02 pm" src="https://user-images.githubusercontent.com/5713523/36687087-7db994c0-1af6-11e8-8862-0321a29602d0.png">
